### PR TITLE
Update phpunit version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5|^8.0",
+        "phpunit/phpunit": "^7.5|^8.0|^9.0",
         "codacy/coverage": "^1.4"
     },
     "suggest": {


### PR DESCRIPTION
Add version constraint "^9.0" to phpunit/phpunit in order to support Laravel 8